### PR TITLE
Add configs for static dir and sqlite file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased changes
 
 - Refactor: replace plugin (#8)
+- Feat: add config (#9)
+    - `static_path`: path of static directory to serve static files
+    - `sqlite_path`: `*.sqlite` file path to store score data
+- Feat: default config (#9)
+    - see `template/.anaqram-server.yaml`
 
 ## 1.0.0
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -40,7 +40,7 @@ runCmd opts path = do
   let plugin = hsequence
              $ #logger <@=> MixLogger.buildPlugin logOpts
             <: #config <@=> pure config
-            <: #sqlite <@=> MixDB.buildPlugin "anaqram.sqlite" 2
+            <: #sqlite <@=> MixDB.buildPlugin (fromString $ config ^. #paths ^. #sqlite) 2
             <: nil
   if | opts ^. #migrate -> Mix.run plugin AnaQRam.migrate
      | otherwise        -> Mix.run plugin AnaQRam.app

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,7 @@ import qualified AnaQRam
 import           Configuration.Dotenv      (defaultConfig, loadFile)
 import           Data.Extensible
 import           Data.Extensible.GetOpt
+import           Data.Fallible
 import           GetOpt                    (withGetOpt')
 import           Mix
 import           Mix.Plugin.Logger         as MixLogger
@@ -35,14 +36,15 @@ type Options = Record
    ]
 
 runCmd :: Options -> FilePath -> IO ()
-runCmd opts path = do
-  config <- AnaQRam.readConfig path
+runCmd opts path = evalContT $ do
+  config <- AnaQRam.readConfig path !?= exit . displayErr
   let plugin = hsequence
              $ #logger <@=> MixLogger.buildPlugin logOpts
             <: #config <@=> pure config
-            <: #sqlite <@=> MixDB.buildPlugin (fromString $ config ^. #paths ^. #sqlite) 2
+            <: #sqlite <@=> MixDB.buildPlugin (fromString $ config ^. #sqlite_path) 2
             <: nil
-  if | opts ^. #migrate -> Mix.run plugin AnaQRam.migrate
-     | otherwise        -> Mix.run plugin AnaQRam.app
+  if | opts ^. #migrate -> lift (Mix.run plugin AnaQRam.migrate)
+     | otherwise        -> lift (Mix.run plugin AnaQRam.app)
   where
     logOpts = #handle @= stdout <: #verbose @= (opts ^. #verbose) <: nil
+    displayErr err = hPutBuilder stderr $ "cannot read config: " <> fromString (show err)

--- a/example/.anaqram-server.yaml
+++ b/example/.anaqram-server.yaml
@@ -1,6 +1,4 @@
-paths:
-  static: ./static
-  sqlite: ./var/anaqram.sqlite
+sqlite_path: ./var/anaqram.sqlite
 
 problems:
 - "りんご"

--- a/example/.anaqram-server.yaml
+++ b/example/.anaqram-server.yaml
@@ -1,3 +1,7 @@
+paths:
+  static: ./static
+  sqlite: ./var/anaqram.sqlite
+
 problems:
 - "りんご"
 - "ゴリラ"

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,5 @@
+Exec
+
+```
+$ docker run --rm -p 8080:8080 -v `pwd`:/work/var anaqram server var/.anaqram-server.yaml
+```

--- a/package.yaml
+++ b/package.yaml
@@ -44,7 +44,7 @@ default-extensions:
 dependencies:
 - base >= 4.7 && < 5
 - rio >= 0.1.1.0
-- extensible >= 0.4.9
+- extensible >= 0.6.1
 - mix
 - mix-json-logger
 - fallible

--- a/package.yaml
+++ b/package.yaml
@@ -62,6 +62,7 @@ dependencies:
 - persistent
 - persistent-template
 - persistent-sqlite
+- th-lift-instances
 
 library:
   source-dirs: src

--- a/src/AnaQRam/API.hs
+++ b/src/AnaQRam/API.hs
@@ -38,10 +38,10 @@ type CRUD
 api :: Proxy API
 api = Proxy
 
-server :: ServerT API (RIO Env)
-server = indexHtml
+server :: FilePath -> ServerT API (RIO Env)
+server staticPath = indexHtml
     :<|> scoreboardHtml
-    :<|> serveDirectoryFileServer "static"
+    :<|> serveDirectoryFileServer staticPath
     :<|> getSizes
     :<|> getProblem
     :<|> getScores

--- a/src/AnaQRam/Cmd.hs
+++ b/src/AnaQRam/Cmd.hs
@@ -14,10 +14,12 @@ app :: RIO Env ()
 app = do
   MixLogger.logInfo "Please accsess to localhost:8080"
   unlift <- askUnliftIO
-  liftIO $ Warp.run 8080 (appWith unlift)
+  staticPath <- asks (view #static . view #paths .view #config)
+  liftIO $ Warp.run 8080 (appWith unlift staticPath)
 
-appWith :: UnliftIO (RIO Env) -> Application
-appWith m = serve api $ hoistServer api (liftIO . unliftIO m) server
+appWith :: UnliftIO (RIO Env) -> FilePath -> Application
+appWith m staticPath =
+  serve api $ hoistServer api (liftIO . unliftIO m) (server staticPath)
 
 migrate :: RIO Env ()
 migrate = do

--- a/src/AnaQRam/Cmd.hs
+++ b/src/AnaQRam/Cmd.hs
@@ -14,7 +14,7 @@ app :: RIO Env ()
 app = do
   MixLogger.logInfo "Please accsess to localhost:8080"
   unlift <- askUnliftIO
-  staticPath <- asks (view #static . view #paths .view #config)
+  staticPath <- asks (view #static_path .view #config)
   liftIO $ Warp.run 8080 (appWith unlift staticPath)
 
 appWith :: UnliftIO (RIO Env) -> FilePath -> Application

--- a/src/AnaQRam/Config/Default.hs
+++ b/src/AnaQRam/Config/Default.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module AnaQRam.Config.Default
+  ( defaultConfig
+  ) where
+
+import           AnaQRam.Config.Internal as X
+import           Data.Yaml.TH            (decodeFile)
+import           Instances.TH.Lift       ()
+
+defaultConfig :: Config
+defaultConfig = $$(decodeFile "./template/.anaqram-server.yaml")

--- a/src/AnaQRam/Config/Internal.hs
+++ b/src/AnaQRam/Config/Internal.hs
@@ -1,0 +1,11 @@
+module AnaQRam.Config.Internal where
+
+import           RIO
+
+import           Data.Extensible
+
+type Config = Record
+  '[ "static_path" >: FilePath
+   , "sqlite_path" >: FilePath
+   , "problems"    >: [Text]
+   ]

--- a/src/AnaQRam/Env.hs
+++ b/src/AnaQRam/Env.hs
@@ -17,7 +17,13 @@ type Env = Record
    ]
 
 type Config = Record
-  '[ "problems" >: [Text]
+  '[ "paths"    >: PathsConfig
+   , "problems" >: [Text]
+   ]
+
+type PathsConfig = Record
+  '[ "static" >: FilePath
+   , "sqlite" >: FilePath
    ]
 
 readConfig :: MonadIO m => FilePath -> m Config

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-14.7
 packages:
 - .
 extra-deps:
-- extensible-0.6
+- extensible-0.6.1
 - membership-0
 - github: matsubara0507/mix.hs
   commit: 90e9f0ff462aba2e78498e57fad1f8bec1e68260

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: extensible-0.6@sha256:57b756098ad50590864bfa3c95c23aa83fa89eedcf2ef019b7c5da6232c1b476,2858
+    hackage: extensible-0.6.1@sha256:d73a5dc13bd00f44ace729f83ce868e81a45ea31c7453a6f8a4a9b5b0591d600,2860
     pantry-tree:
-      size: 2294
-      sha256: 71f8b5cead10453ba042710c8a379affcab2f7bbac0c348d84610cb59697c0a3
+      size: 2354
+      sha256: 9fadd24af89df601f19d57893b513d1742a1942670d6d2e73e79fb4b7aabce65
   original:
-    hackage: extensible-0.6
+    hackage: extensible-0.6.1
 - completed:
     hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
     pantry-tree:

--- a/template/.anaqram-server.yaml
+++ b/template/.anaqram-server.yaml
@@ -1,0 +1,4 @@
+static_path: ./static
+sqlite_path: ./anaqram.sqlite
+
+problems: []


### PR DESCRIPTION
Close: #6 

- Feat: add config 
    - `static_path`: path of static directory to serve static files
    - `sqlite_path`: `*.sqlite` file path to store score data
- Feat: default config
    - see `template/.anaqram-server.yaml`
